### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/src/services/GithubService.ts
+++ b/src/services/GithubService.ts
@@ -45,7 +45,7 @@ export class GithubService {
 
       // Filter out forked repositories and transform to our Project interface
       return repos
-        .filter(repo => !repo.fork && !repo.name.includes('.github.io'))
+        .filter(repo => !repo.fork && !/\.github\.io$/.test(repo.name))
         .map(repo => ({
           id: repo.id,
           name: repo.name.replace(/-/g, " "),


### PR DESCRIPTION
Potential fix for [https://github.com/MikePfunk28/mikepfunk-mobile-mock/security/code-scanning/1](https://github.com/MikePfunk28/mikepfunk-mobile-mock/security/code-scanning/1)

To fix the issue, we need to ensure that the check for `.github.io` is performed in a way that accurately identifies repositories intended to be excluded. Instead of using a substring check, we should explicitly match the repository name against a whitelist or use a stricter pattern that ensures `.github.io` appears only as a suffix.

The best way to fix this is to use a regular expression to check if the repository name ends with `.github.io`. This ensures that only repositories with names explicitly ending in `.github.io` are excluded, avoiding false positives caused by substrings appearing elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
